### PR TITLE
Update deprecated packages & API calls

### DIFF
--- a/api.py
+++ b/api.py
@@ -57,7 +57,7 @@ def parse_arguments():
 
     parser.add_argument("--max_num_worker", type=int, default=0, help="maximum number of workers for dataloader")
     parser.add_argument(
-        "--model", type=str, default="gpt3-xl", help="model used for decoding. Note that 'gpt3' are the smallest models."
+        "--model", type=str, default="gpt-3.5-turbo-16k", help="model used for decoding. Note that 'gpt-3.5-turbo' are the smallest models."
     )
     parser.add_argument(
         "--method", type=str, default="auto_cot", choices=["zero_shot", "zero_shot_cot", "few_shot", "few_shot_cot", "auto_cot"], help="method"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sklearn
+scikit-learn
 matplotlib
 sentence-transformers
 jupyter

--- a/utils.py
+++ b/utils.py
@@ -58,47 +58,22 @@ def decoder_for_gpt3(args, input, max_length):
     # https://beta.openai.com/account/api-keys
     # openai.api_key = "[Your OpenAI API Key]"
     
-    # Specify engine ...
-    # Instruct GPT3
-    if args.model == "gpt3":
-        engine = "text-ada-001"
-    elif args.model == "gpt3-medium":
-        engine = "text-babbage-001"
-    elif args.model == "gpt3-large":
-        engine = "text-curie-001"
-    elif args.model == "gpt3-xl":
-        engine = "text-davinci-002"
-    elif args.model == "text-davinci-001":
-        engine = "text-davinci-001"
-    elif args.model == "code-davinci-002":
-        engine = "code-davinci-002"
-    else:
-        raise ValueError("model is not properly defined ...")
         
-    if ("few_shot" in args.method or "auto" in args.method)  and engine == "code-davinci-002":
-        response = openai.Completion.create(
-          engine=engine,
-          prompt=input,
-          max_tokens=max_length,
-          temperature=args.temperature,
-          top_p=1,
-          frequency_penalty=0,
-          presence_penalty=0,
-          stop=["\n"]
-        )
-    else:
-        response = openai.Completion.create(
-            engine=engine,
-            prompt=input,
-            max_tokens=max_length,
-            temperature=args.temperature,
-            top_p=1,
-            frequency_penalty=0,
-            presence_penalty=0,
-            stop=None
-        )
+    response = openai.chat.completions.create(
+        model=args.model,
+        messages=[{
+            "role": "user",
+            "content": input
+        }],
+        max_tokens=max_length,
+        temperature=args.temperature,
+        top_p=1,
+        frequency_penalty=0,
+        presence_penalty=0,
+        stop=None
+    )
 
-    return response["choices"][0]["text"]
+    return response.choices[0].message.content
 
 class Decoder():
     def __init__(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Updated package name from `sklearn` to `scikit-learn` due to the deprecation of `sklearn`.
- Replaced deprecated OpenAI API methods with their latest versions.
- Replaced GPT-3 with GPT-3.5 in response to the deprecation of GPT-3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
